### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     name='spur',
     version='0.3.7',
     description='Run commands and manipulate files locally or over SSH using the same interface',
-    long_description=read("README"),
+    long_description=read("README.md"),
     author='Michael Williamson',
     url='http://github.com/mwilliamson/spur.py',
     keywords="ssh shell subprocess process",


### PR DESCRIPTION
Ensure setup.py will compile package.
Linux distributions like openSUSE are heavily using python setup.py to bring Python lib and not much pip.
