### PR TITLE
results.py: Use "replace" error handling scheme when decoding

### DIFF
--- a/spur/results.py
+++ b/spur/results.py
@@ -34,4 +34,4 @@ class RunProcessError(RuntimeError):
 
 
 def _decode(raw_bytes):
-    return raw_bytes.decode(locale.getdefaultlocale()[1])
+    return raw_bytes.decode(locale.getdefaultlocale()[1], "replace")


### PR DESCRIPTION
When running certain commands (e.g. "dpkg -i"), the output sometimes can't be decoded with the default strict error handling scheme.
