### PR TITLE
Fixed error in ssh.MinimalShellType

### DIFF
--- a/spur/ssh.py
+++ b/spur/ssh.py
@@ -66,7 +66,7 @@ class MinimalShellType(object):
         
     
     def _unsupported_argument_error(self, name):
-        raise UnsupportedArgumentError("'{0}' is not supported when using a minimal shell".format(name))
+        return UnsupportedArgumentError("'{0}' is not supported when using a minimal shell".format(name))
 
 
 class ShShellType(object):


### PR DESCRIPTION
The "_unsupported_argument_error" method was raising the UnsupportedArgumentError exception, instead of returning it to "generate_run_command".