### PR TITLE
Fix performance problem when writing output to file descriptors

### DIFF
--- a/spur/io.py
+++ b/spur/io.py
@@ -71,7 +71,7 @@ class _ContinuousReader(object):
         output_buffer = StringIO()
         while True:
             try:
-                output = self._file_in.read(1)
+                output = self._file_in.read(4096)
             except IOError:
                 if self._is_pty:
                     output = b""

--- a/spur/io.py
+++ b/spur/io.py
@@ -1,6 +1,6 @@
 import threading
 import os
-
+from StringIO import StringIO
 
 class IoHandler(object):
     def __init__(self, channels, encoding):
@@ -68,7 +68,7 @@ class _ContinuousReader(object):
         return self._output
     
     def _capture_output(self):
-        output_buffer = []
+        output_buffer = StringIO()
         while True:
             try:
                 output = self._file_in.read(1)
@@ -80,7 +80,7 @@ class _ContinuousReader(object):
             if output:
                 if self._file_out is not None:
                     self._file_out.write(output)
-                output_buffer.append(output)
+                output_buffer.write(output)
             else:
-                self._output = b"".join(output_buffer)
+                self._output = output_buffer.getvalue()
                 return


### PR DESCRIPTION
The _ContinuousReader class uses an incredible small output buffer (a single byte). This leads to terrible performance. Consider the following simple test program:

``` python
#!/usr/bin/python
import spur

s = spur.SshShell("localhost", port=22)
res = s.run(["echo", "connected"])
print res.output
outputfile = file("output", "w")
res = s.run(["cat", "spur/input"], stdout=outputfile)
print res.return_code, len(res.output)
```

If "spur/input" is a 100MB input file on the server, then this simple copy operation (localhost-to-localhost) takes several minutes. After these fixes, it takes a few seconds.
