### PR TITLE
Added a sock parameter to SshShell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,19 @@ Optional arguments:
   be raised if the file can't be read.
   Set to ``False`` to disable this behaviour.
 
+* ``sock`` -- an open socket or socket-like object (such as a ``paramiko.Channel``) to use
+  for communication to the target host. One could setup a proxy command using this:
+
+  .. code-block:: python
+
+      sock=paramiko.proxy.ProxyCommand("ssh -q -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+                                       "{proxy_user}@{proxy_ip} nc -q0 {target_ip} 22")
+
+  For more information see:
+
+  * ``paramiko.Channel`` : http://docs.paramiko.org/en/latest/api/channel.html
+  * ``ProxyCommand`` support : http://docs.paramiko.org/en/latest/api/proxy.html
+
 Shell interface
 ---------------
 

--- a/spur/ssh.py
+++ b/spur/ssh.py
@@ -125,7 +125,8 @@ class SshShell(object):
             missing_host_key=None,
             shell_type=None,
             look_for_private_keys=True,
-            load_system_host_keys=True):
+            load_system_host_keys=True,
+            sock=None):
         
         if shell_type is None:
             shell_type = ShellTypes.sh
@@ -140,7 +141,8 @@ class SshShell(object):
         self._look_for_private_keys = look_for_private_keys
         self._load_system_host_keys = load_system_host_keys
         self._closed = False
-        
+        self._sock = sock
+
         if missing_host_key is None:
             self._missing_host_key = MissingHostKey.raise_error
         else:
@@ -263,7 +265,8 @@ class SshShell(object):
                 password=self._password,
                 key_filename=self._private_key_file,
                 look_for_keys=self._look_for_private_keys,
-                timeout=self._connect_timeout
+                timeout=self._connect_timeout,
+                sock=self._sock
             )
             self._client = client
         return self._client

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -4,14 +4,22 @@ import spur
 import spur.ssh
 
 
+def _int_or_none(val):
+    return int(val) if val is not None else None
+
+
+HOSTNAME = os.environ.get("TEST_SSH_HOSTNAME", "127.0.0.1")
+USERNAME = os.environ["TEST_SSH_USERNAME"]
+PASSWORD = os.environ["TEST_SSH_PASSWORD"]
+PORT = _int_or_none(os.environ.get("TEST_SSH_PORT"))
+
+
 def create_ssh_shell(missing_host_key=None, shell_type=None):
-    port_var = os.environ.get("TEST_SSH_PORT")
-    port = int(port_var) if port_var is not None else None
     return spur.SshShell(
-        hostname=os.environ.get("TEST_SSH_HOSTNAME", "127.0.0.1"),
-        username=os.environ["TEST_SSH_USERNAME"],
-        password=os.environ["TEST_SSH_PASSWORD"],
-        port=port,
+        hostname=HOSTNAME,
+        username=USERNAME,
+        password=PASSWORD,
+        port=PORT,
         missing_host_key=(missing_host_key or spur.ssh.MissingHostKey.accept),
         shell_type=shell_type,
     )


### PR DESCRIPTION
It is a pass-through to the paramiko.client.connect method

resolves #41

Another part of this feature could be to have an helper to craft the proxy_command
that can be passed to the sock= param