### PR TITLE
Check the result of the cwd in SshShell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,6 +152,9 @@ instance, ``shell.run(["echo", "$PATH"])`` will print the literal string
 Raises ``spur.NoSuchCommandError`` if trying to execute a non-existent
 command.
 
+Raises ``spur.NoSuchDirectoryError`` if trying to change to a non-existent
+directory.
+
 Optional arguments:
 
 * ``cwd`` -- change the current directory to this value before
@@ -189,6 +192,9 @@ object representing the running process.
 
 Raises ``spur.NoSuchCommandError`` if trying to execute a non-existent
 command.
+
+Raises ``spur.NoSuchDirectoryError`` if trying to change to a non-existent
+directory.
 
 open(path, mode="r")
 ~~~~~~~~~~~~~~~~~~~~
@@ -271,6 +277,13 @@ NoSuchCommandError
 ``NoSuchCommandError`` has the following properties:
 
 * ``command`` -- the command that could not be found
+
+NoSuchDirectoryError
+~~~~~~~~~~~~~~~~~~~~
+
+``NoSuchDirectoryError`` has the following properties:
+
+* ``directory`` -- the directory that could not be found
 
 API stability
 -------------

--- a/spur/__init__.py
+++ b/spur/__init__.py
@@ -1,7 +1,7 @@
 from .local import LocalShell
 from .ssh import SshShell
 from .results import RunProcessError
-from .errors import NoSuchCommandError, CommandInitializationError
+from .errors import NoSuchCommandError, CommandInitializationError, NoSuchDirectoryError
 
 __all__ = ["LocalShell", "SshShell", "RunProcessError", "NoSuchCommandError",
-    "CommandInitializationError"]
+           "CommandInitializationError", "NoSuchDirectoryError"]

--- a/spur/errors.py
+++ b/spur/errors.py
@@ -14,3 +14,11 @@ class CommandInitializationError(Exception):
 """Error while initializing command. The most likely cause is an unsupported shell. Try using a minimal shell type when calling 'spawn' or 'run'.
 (Failed to parse line '{0}' as integer)""".format(line)
         )
+
+
+class NoSuchDirectoryError(OSError):
+
+    def __init__(self, directory):
+        message = "No such directory: {0}".format(directory)
+        super(type(self), self).__init__(message)
+        self.directory = directory

--- a/tests/ssh_tests.py
+++ b/tests/ssh_tests.py
@@ -123,6 +123,9 @@ class MinimalSshProcessTests(ProcessTestSet, MinimalSshTestMixin):
     
     can_get_process_id_of_process_if_store_pid_is_true = None
     can_send_signal_to_process_if_store_pid_is_set = None
+
+    exception_is_raised_if_cwd_does_not_exist = None
+    can_find_command_in_cwd = None
     
     @istest
     def cannot_store_pid(self):

--- a/tests/ssh_tests.py
+++ b/tests/ssh_tests.py
@@ -124,7 +124,10 @@ class MinimalSshProcessTests(ProcessTestSet, MinimalSshTestMixin):
     can_get_process_id_of_process_if_store_pid_is_true = None
     can_send_signal_to_process_if_store_pid_is_set = None
 
-    exception_is_raised_if_cwd_does_not_exist = None
+    # cwd is not supported when using a minimal shell
+    using_non_existent_cwd_raises_no_such_directory_exception = None
+    using_non_existent_cwd_and_command_raises_no_such_directory_exception = None
+    using_non_existent_command_and_correct_cwd_raises_no_such_command_exception = None
     can_find_command_in_cwd = None
     
     @istest


### PR DESCRIPTION
Using the cwd argument used to run something like that:
$ cd '/some/path'; command -v 'ls' > /dev/null 2>&1 ||
  which 'ls' > /dev/null 2>&1; echo $?; exec 'ls'

Even if the directory doesn't exist, the command is run.
I first tried to change it to:
$ cd '/some/path' && { command -v 'ls' > /dev/null 2>&1 ||
  which 'ls' > /dev/null 2>&1; echo $?; exec 'ls'; }

But we can't check the which/command result if the cd fails. To minimize
the impact, I changed it to:
$ cd '/some/path' 2>/dev/null; command -v 'ls' > /dev/null 2>&1 ||
  which 'ls' > /dev/null 2>&1; echo $?; cd '/some/path' && exec 'ls'

We have to run cd before to check if the command exists because we might
run a script in the cwd directory.
So we don't catch if this cd fails and run it again just before the exec
where we catch it. The only drawback is that if a command is not found
because the cwd is incorrect, we'll raise NoSuchCommandError instead of
RunProcessError.

Fixes #46