### PR TITLE
Do not leave python 2 blocked while SSH processes run (fixes #61)

### DIFF
--- a/spur/ssh.py
+++ b/spur/ssh.py
@@ -380,6 +380,13 @@ class SshProcess(object):
         self._shell.run(["kill", "-{0}".format(signal), str(self.pid)])
         
     def wait_for_result(self):
+        if sys.version_info[0] < 3:     # Python 2 only
+            # Allow rise of exceptions (e.g., SIGINT for Ctrl+c) that might
+            # cancel process execution.  Python 2 does not raise exceptions
+            # during blocking io, so we first wait for the process to finish and
+            # only then pull the result.
+            while self.is_running():
+                time.sleep(0.1)
         if self._result is None:
             self._result = self._generate_result()
             


### PR DESCRIPTION
If we wait for an SSH process in Python 2, there is no way to cancel the
script unless we send SIGKILL to it (e.g., SIGINT won't work).

The following example will never raise KeyboardInterrupt in Python 2 until
the process finishes:

  import spur
  s = spur.SshShell(hostname="localhost",
                    missing_host_key=spur.ssh.MissingHostKey.accept)
  s.run(["bash", "-c", "sleep 100000"])

We instead add an active wait loop (only in Python 2) so that it can catch
up with queued signals.