### PR TITLE
Adding in SSH forwarding to spur using Paramiko's AgentRequestHandler

### DIFF
--- a/spur/ssh.py
+++ b/spur/ssh.py
@@ -178,6 +178,7 @@ class SshShell(object):
             channel = self._get_ssh_transport().open_session()
         except EOFError as error:
             raise self._connection_error(error)
+        paramiko.agent.AgentRequestHandler(channel)
         if use_pty:
             channel.get_pty()
         channel.exec_command(command_in_cwd)

--- a/tests/ssh_tests.py
+++ b/tests/ssh_tests.py
@@ -95,6 +95,13 @@ def an_open_socket_can_be_used_for_ssh_connection_with_sock_argument():
         assert_equal(b"hello\n", result.output)
 
 
+@istest
+def ssh_agent_key_forwarding_successful():
+    with create_ssh_shell(missing_host_key=spur.ssh.MissingHostKey.accept) as shell:
+        auth_sock = shell.run(["printenv", "SSH_AUTH_SOCK"])
+        assert auth_sock is not None
+
+
 def _create_shell_with_wrong_port(**kwargs):
     return spur.SshShell(
         username=USERNAME,


### PR DESCRIPTION
Adding in SSH forwarding to spur using[ Paramiko's AgentRequestHandler](http://docs.paramiko.org/en/2.4/api/agent.html#paramiko.agent.AgentRequestHandler).  Fixes #50.

Also includes test that is only confirmed to work in Unix/Linux. Not sure how to write a Windows test for this, but I believe it will fail due to the lack of the printenv command and the environment variable SSH_AUTH_SOCK.